### PR TITLE
Fix printing

### DIFF
--- a/neuromllite/BaseTypes.py
+++ b/neuromllite/BaseTypes.py
@@ -89,7 +89,6 @@ class Base(object):
             #if verbose: print_v(" >   Attribute %s is a child: %s (%s)..."%(name,self.children[name],type(self.children[name])))
             return self.children[name]
 
-        print_v('No field or child: %s in %s'%(name, self.id))
         return None
 
 

--- a/neuromllite/test/test_utils.py
+++ b/neuromllite/test/test_utils.py
@@ -1,5 +1,8 @@
 from neuromllite import *
 from neuromllite.utils import *
+
+from neuromllite.utils import _val_info
+
 import numpy as np
 
 from test_base import get_example_network, get_example_simulation
@@ -99,6 +102,8 @@ class TestUtils(unittest.TestCase):
 
         return True
 
+    def test_val_info_tuple(self):
+        _val_info(tuple(1,2))
 
 if __name__ == "__main__":
     tu = TestUtils()

--- a/neuromllite/test/test_utils.py
+++ b/neuromllite/test/test_utils.py
@@ -103,7 +103,10 @@ class TestUtils(unittest.TestCase):
         return True
 
     def test_val_info_tuple(self):
-        _val_info(tuple(1,2))
+        print(_val_info((1,2)))
+        print(_val_info((("test", 1), 2)))
+        print(_val_info((("test", object()), 2)))
+
 
 if __name__ == "__main__":
     tu = TestUtils()

--- a/neuromllite/utils.py
+++ b/neuromllite/utils.py
@@ -177,6 +177,10 @@ def _val_info(param_val):
         pp = '%s'%param_val
         pp=pp.replace('\n','')
         #pp+=' (TF %s %s)'%(param_val.shape,param_val.dtype)
+    elif type(param_val) == tuple:
+        # If param_val is a tuple, recursively print its elements
+        # separated by commas and wrapped in parentheses
+        pp = "(" + ', '.join([_val_info(el) for el in param_val]) + ")"
     else:
         pp = '%s'%param_val
         t = type(param_val)


### PR DESCRIPTION
This pull request fixes two minor issues I came across when working on MDF stuff. The first is a crash I encountered when implementing multiple return values in MDF. The _val_info function in neuromllite.utils could not handle when values were tuples which I needed to implement return values. The second fix is a minor issue with a print statement that is in `Base.__gettattr__`. IPython seems to expect that getattr has no side effects and invokes it on all sorts of attributes may or may not exist. Here is an example:

```
IPython 7.22.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from neuromllite import Base

In [2]: Base()
Out[2]: neuromllite >>> No field or child: _ipython_canary_method_should_not_exist_ in None
neuromllite >>> No field or child: _repr_mimebundle_ in None
Base (None)

In [3]: quit()
```